### PR TITLE
Change service URL to login page

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   "author": "Yuriy Badalyantc <lmnet89@gmail.com>",
   "repository": "https://github.com/lmnet/franz-recipe-notion",
   "config": {
-    "serviceURL": "https://notion.so"
+    "serviceURL": "https://notion.so/login"
   }
 }


### PR DESCRIPTION
Small change, would by default make the notion recipe open the login screen upon adding the service (in keeping with other official recipes)